### PR TITLE
fix file variants type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-health/client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "description": "Official TypeScript bindings for the Source Health API",
   "scripts": {

--- a/src/resources/File.ts
+++ b/src/resources/File.ts
@@ -41,7 +41,7 @@ export interface File {
    * variants available depend on the file's purpose. Files with the `photo` purpose
    * will have variants.
    */
-  variants: Record<string, unknown>
+  variants: Record<string, string>
   /**
    * Timestamp of when the url to access the file expires
    */


### PR DESCRIPTION
Fixes `File.variants` to be `Record<string,string>`