### PR TITLE
Update for license code -> type

### DIFF
--- a/src/resources/License.ts
+++ b/src/resources/License.ts
@@ -4,13 +4,13 @@ import { SourceRequestOptions } from '../SourceClient'
 import { User } from './User'
 import { Expandable } from './shared'
 
-export interface LicenseCode {
+export interface LicenseType {
   /**
-   * The license code.
+   * Code for the license type.
    */
   code: string
   /**
-   * Full description of the license code
+   * Full description of the license type.
    */
   description: string
 }
@@ -31,9 +31,9 @@ export interface License {
    */
   user: Expandable<User>
   /**
-   * Code describing the license type.
+   * The license type.
    */
-  code: LicenseCode
+  type: LicenseType
   /**
    * Region the license is associated with. This is represented as an ISO-3166-2:US
    * code
@@ -110,10 +110,11 @@ export interface LicenseListParams {
    */
   user?: Array<string>
   /**
-   * Filter results by code. If multiple codes are provided, licenses matching any of
-   * the provided codes will be returned.
+   * Filter results by type. The corresponding code for the license type should be
+   * provided. If multiple codes are provided, licenses matching any of the provided
+   * license types will be returned.
    */
-  code?: Array<string>
+  type?: Array<string>
   /**
    * Filter results by region. If multiple regions are provided, licenses matching
    * any of the provided regions will be returned.
@@ -126,7 +127,7 @@ export interface LicenseListParams {
   status?: Array<LicenseListParamsStatus>
 }
 
-export interface LicenseCreateParamsCode {
+export interface LicenseCreateParamsType {
   code: string
 }
 
@@ -138,9 +139,9 @@ export interface LicenseCreateParams {
    */
   user: string
   /**
-   * Code describing the license type.
+   * The license type.
    */
-  code: LicenseCreateParamsCode
+  type: LicenseCreateParamsType
   /**
    * Region the license is associated with. This is represented as an ISO-3166-2:US
    * code

--- a/src/resources/TaskDefinition.ts
+++ b/src/resources/TaskDefinition.ts
@@ -5,13 +5,13 @@ import { CareTeamRole } from './CareTeamRole'
 import { Queue } from './Queue'
 import { Expandable } from './shared'
 
-export interface TaskDefinitionLicenseCode {
+export interface TaskDefinitionLicenseType {
   /**
-   * The license code.
+   * Code for the license type.
    */
   code: string
   /**
-   * Full description of the license code
+   * Full description of the license type.
    */
   description: string
 }
@@ -54,7 +54,7 @@ export interface TaskDefinition {
    * Providing any value will override the entire array. Providing null or an empty
    * array will empty out the array.
    */
-  license_codes: Array<TaskDefinitionLicenseCode>
+  license_types: Array<TaskDefinitionLicenseType>
   /**
    * Timestamp of when the task definition was created.
    */
@@ -114,7 +114,7 @@ export interface TaskDefinitionListParams {
   queue?: Array<string>
 }
 
-export interface TaskDefinitionCreateParamsLicenseCode {
+export interface TaskDefinitionCreateParamsLicenseType {
   code: string
 }
 
@@ -148,10 +148,10 @@ export interface TaskDefinitionCreateParams {
    * Providing any value will override the entire array. Providing null or an empty
    * array will empty out the array.
    */
-  license_codes?: Array<TaskDefinitionCreateParamsLicenseCode> | null
+  license_types?: Array<TaskDefinitionCreateParamsLicenseType> | null
 }
 
-export interface TaskDefinitionUpdateParamsLicenseCode {
+export interface TaskDefinitionUpdateParamsLicenseType {
   code: string
 }
 
@@ -185,7 +185,7 @@ export interface TaskDefinitionUpdateParams {
    * Providing any value will override the entire array. Providing null or an empty
    * array will empty out the array.
    */
-  license_codes?: Array<TaskDefinitionUpdateParamsLicenseCode> | null
+  license_types?: Array<TaskDefinitionUpdateParamsLicenseType> | null
 }
 
 export class TaskDefinitionResource extends Resource {

--- a/src/resources/scheduling/Appointment.ts
+++ b/src/resources/scheduling/Appointment.ts
@@ -348,7 +348,8 @@ export interface AppointmentCreateParams {
    * By default, Source runs a number of checks to prevent you from creating
    * appointments that seem unsafe. For example, we prevent you from creating
    * appointments that take place in the past, from creating appointments outside of
-   * the bookable window for an appointment type, or from creating appointments
+   * the bookable window for an appointment type, from creating appointments that
+   * require licensure with unlicensed participants, or from creating appointments
    * during which one of the participants has a conflict.
    *
    * When calling the appointments endpoints with your API key, you can override this
@@ -454,7 +455,8 @@ export interface AppointmentUpdateParams {
    * By default, Source runs a number of checks to prevent you from creating
    * appointments that seem unsafe. For example, we prevent you from creating
    * appointments that take place in the past, from creating appointments outside of
-   * the bookable window for an appointment type, or from creating appointments
+   * the bookable window for an appointment type, from creating appointments that
+   * require licensure with unlicensed participants, or from creating appointments
    * during which one of the participants has a conflict.
    *
    * When calling the appointments endpoints with your API key, you can override this

--- a/src/resources/scheduling/AppointmentType.ts
+++ b/src/resources/scheduling/AppointmentType.ts
@@ -18,13 +18,13 @@ export type AppointmentTypeRoutingStrategy =
   | 'care_team_hybrid'
   | 'round_robin'
 
-export interface AppointmentTypeLicenseCode {
+export interface AppointmentTypeLicenseType {
   /**
-   * The license code.
+   * Code for the license type.
    */
   code: string
   /**
-   * Full description of the license code
+   * Full description of the license type.
    */
   description: string
 }
@@ -178,7 +178,7 @@ export interface AppointmentType {
    * value will override the entire array. Providing null or an empty array will
    * empty out the array.
    */
-  license_codes: Array<AppointmentTypeLicenseCode>
+  license_types: Array<AppointmentTypeLicenseType>
   /**
    * Timestamp when the appointment type was created.
    */
@@ -263,7 +263,7 @@ export type AppointmentTypeCreateParamsRoutingStrategy =
   | 'care_team_hybrid'
   | 'round_robin'
 
-export interface AppointmentTypeCreateParamsLicenseCode {
+export interface AppointmentTypeCreateParamsLicenseType {
   code: string
 }
 
@@ -404,7 +404,7 @@ export interface AppointmentTypeCreateParams {
    * value will override the entire array. Providing null or an empty array will
    * empty out the array.
    */
-  license_codes?: Array<AppointmentTypeCreateParamsLicenseCode> | null
+  license_types?: Array<AppointmentTypeCreateParamsLicenseType> | null
   /**
    * Whether or not to create a video call for appointments of this type. Defaults to
    * false.
@@ -427,7 +427,7 @@ export type AppointmentTypeUpdateParamsRoutingStrategy =
   | 'care_team_hybrid'
   | 'round_robin'
 
-export interface AppointmentTypeUpdateParamsLicenseCode {
+export interface AppointmentTypeUpdateParamsLicenseType {
   code: string
 }
 
@@ -568,7 +568,7 @@ export interface AppointmentTypeUpdateParams {
    * value will override the entire array. Providing null or an empty array will
    * empty out the array.
    */
-  license_codes?: Array<AppointmentTypeUpdateParamsLicenseCode> | null
+  license_types?: Array<AppointmentTypeUpdateParamsLicenseType> | null
   /**
    * Whether or not to create a video call for appointments of this type. Defaults to
    * false.


### PR DESCRIPTION
`license.code` was updated to `license.type` and resources pointing at `license_codes` were changed to `license_types`