### PR TITLE
add option to log exceptions after we attempt to parse json

### DIFF
--- a/src/adapter/NodeAdapter.ts
+++ b/src/adapter/NodeAdapter.ts
@@ -80,7 +80,7 @@ export default class NodeHttpClient implements HttpAdapter {
           } catch (ex) {
             if (this.options.dangerouslyLogRequestExceptions) {
               // eslint-disable-next-line no-console
-              console.error('Failed to resolve data, we caught this error:', ex, data)
+              console.error('Failed to resolve data, Source caught this error:', ex, data)
             }
 
             reject(


### PR DESCRIPTION
# Context

We've recently begun seeing tests fail due to an invalid response from the server. We are uncertain of the cause, and don't have a way to access the error easily. This PR adds a configuration option to the NodeAdapter, `dangerouslyLogRequestExceptions`, which will log the invalid response exception as well as the data that we received from the response. I added the prefix `dangerously` to indicate that this should not be used in production, there is nothing strictly dangerous about this change.

## Demo

I did a quick `yarn link` into the test suite to show that this will work.

<img width="803" alt="Screen Shot 2022-04-19 at 3 32 32 PM" src="https://user-images.githubusercontent.com/177652/164086255-5a5a69af-7aa2-4f55-98ba-bea80c2ee4b6.png">

