### PR TITLE
Add member list params, user title and suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,30 @@
 # Source Client Changelog
 
+## v1.1
+
+### New API Features
+
+- Add 'title' and 'suffix' to users
+- New member list filter params:
+  - care_team
+  - enrollment_status
+  - region
+  - sex_at_birth
+  - gender_identity
+- New member list sort params
+
+### Backwards Incompatibility Changes
+
+- Member search filter param 'email' becomes an array of email addresses.
+
 ## v1.0
 
 ### Backwards Incompatible Changes and Deprecations
 
 - Authentication classes have been renamed as they collided with API resources. Note that no changes were made to the behavior of these classes, and only the names were changed. The following changes were made:
-   - `ApiKey` -> `ApiKeyAuthentication`
-   - `UserKey` -> `UserAuthentication`
-   - `Token` -> `JWTAuthentication`
+  - `ApiKey` -> `ApiKeyAuthentication`
+  - `UserKey` -> `UserAuthentication`
+  - `Token` -> `JWTAuthentication`
   - `Anonymous` -> `AnonymousAuthentication`
 - `CareTeamRole` resource has been removed. Its usage for user categorization can be replaced by Groups, and its usage in task routing can be replaced by Queues.
 - `Message` resources can now have a `sender` pointing to an `ApiKey`, in addition to the typical `User` and `Member`.
@@ -19,7 +36,7 @@
 - Comments
 - Appointment Statuses
 - Account Branding Logos
-- Previous Values for *.updated events
+- Previous Values for \*.updated events
 
 ### Other Changes
 

--- a/src/resources/Member.ts
+++ b/src/resources/Member.ts
@@ -223,6 +223,24 @@ export interface MemberListResponse {
   has_more: boolean
 }
 
+export type MemberListParamsSort =
+  | 'created_at'
+  | 'name'
+  | 'date_of_birth'
+  | '-created_at'
+  | '-name'
+  | '-date_of_birth'
+export type MemberListParamsEnrollmentStatus = 'enrolled' | 'not_enrolled'
+export type MemberListParamsSexAtBirth = 'male' | 'female' | 'other' | 'undisclosed'
+export type MemberListParamsGenderIdentity =
+  | 'female'
+  | 'male'
+  | 'non_binary'
+  | 'other'
+  | 'transgender_female'
+  | 'transgender_male'
+  | 'undisclosed'
+
 export interface MemberListParams {
   /**
    * A cursor for use in pagination. `ending_before` is an object ID that defines
@@ -244,15 +262,48 @@ export interface MemberListParams {
    */
   limit?: number
   /**
+   * Sort field for the results. A '-' prefix indicates sorting by that field in
+   * descending order, otherwise the order will be ascending.
+   */
+  sort?: MemberListParamsSort
+  /**
    * Limit results to members tagged with the provided tag. You may provide either
    * tag IDs or tag names for previously created tags. If multiple tags are provided,
    * searches for members containing any of the provided tags.
    */
   tag?: Array<string>
   /**
-   * Limit results to members with the given email.
+   * Limit results to members with the specified email. If multiple emails are
+   * provided, members who have any of the emails are returned.
    */
-  email?: string
+  email?: Array<string>
+  /**
+   * Filter results to members who have a specified user on their care team. Users
+   * must be provided as a list of user identifiers. If multiple users are provided,
+   * members who have any of the specified users on their care team are returned.
+   */
+  care_team?: Array<string>
+  /**
+   * Filter results to members who have a specified enrollment status.
+   */
+  enrollment_status?: Array<MemberListParamsEnrollmentStatus>
+  /**
+   * Filter results to members whose addresses match the specified region. In the US
+   * this should be the two-letter state code. If multiple regions are provided,
+   * members who are located in any of the specified regions are returned.
+   */
+  region?: Array<string>
+  /**
+   * Filter results to members who have a specified sex at birth. If multiple sexes
+   * at birth are provided, members who have any of those specified are returned.
+   */
+  sex_at_birth?: Array<MemberListParamsSexAtBirth>
+  /**
+   * Filter results to members who have a specified gender identity. You must specify
+   * the `gender_identity.value`. If multiple gender identities are provided, members
+   * who have any of those specified are returned.
+   */
+  gender_identity?: Array<MemberListParamsGenderIdentity>
 }
 
 export type MemberCreateParamsSexAtBirth = 'male' | 'female' | 'other' | 'undisclosed'

--- a/src/resources/User.ts
+++ b/src/resources/User.ts
@@ -18,6 +18,10 @@ export interface User {
    */
   id: string
   /**
+   * Title of this user.
+   */
+  title: string | null
+  /**
    * First name of the user.
    */
   first_name: string | null
@@ -25,6 +29,10 @@ export interface User {
    * Last name of the user.
    */
   last_name: string | null
+  /**
+   * Suffix for this user.
+   */
+  suffix: string | null
   /**
    * Display text that describes the user's title. The display title will appear in
    * the Source application and the member experience SDKs but will not affect any
@@ -152,6 +160,10 @@ export type UserCreateParamsRole = 'owner' | 'administrator' | 'developer' | 'cl
 
 export interface UserCreateParams {
   /**
+   * Title of this user.
+   */
+  title?: string | null
+  /**
    * First name of the user.
    */
   first_name: string
@@ -159,6 +171,10 @@ export interface UserCreateParams {
    * Last name of the user.
    */
   last_name: string
+  /**
+   * Suffix for this user.
+   */
+  suffix?: string | null
   /**
    * Display text that describes the user's title. The display title will appear in
    * the Source application and the member-facing Elements SDK but will not affect
@@ -209,6 +225,10 @@ export type UserUpdateParamsRole = 'owner' | 'administrator' | 'developer' | 'cl
 
 export interface UserUpdateParams {
   /**
+   * Title of this user.
+   */
+  title?: string | null
+  /**
    * First name of the user.
    */
   first_name?: string
@@ -216,6 +236,10 @@ export interface UserUpdateParams {
    * Last name of the user.
    */
   last_name?: string
+  /**
+   * Suffix for this user.
+   */
+  suffix?: string | null
   /**
    * Display text that describes the user's title. The display title will appear in
    * the Source application and the member-facing Elements SDK but will not affect


### PR DESCRIPTION
### New API Features:

- Add 'title' and 'suffix' to users
- New member list filter params:
  - care_team
  - enrollment_status
  - region
  - sex_at_birth
  - gender_identity
- New member list sort params

### Backwards Incompatibility Changes:

- Member search filter param 'email' becomes an array of email addresses.
